### PR TITLE
bug/3 :: incorrect reference for practitionerrole

### DIFF
--- a/pages/_includes/au-pd-practitionerrole-search.md
+++ b/pages/_includes/au-pd-practitionerrole-search.md
@@ -57,15 +57,15 @@ Chained search (via Practitioner) based on family, given and/or any name.
 -----------
 **Search: Provider Role**
 
-Search based on role code.
+Search based on role.
 
-`GET [base]/PractitionerRole?code=[system]|[code]`
+`GET [base]/PractitionerRole?role=[system]|[code]`
 
-*Example:* `GET [base]/PractitionerRole?code=http://snomed.info/sct|397897005`
+*Example:* `GET [base]/PractitionerRole?role=http://snomed.info/sct|397897005`
 
 *Support:*
 
-* MUST support search PractitionerRole by code.
+* MUST support search PractitionerRole by role.
 
 *Implementation Notes:* [(how to search by token)]
 

--- a/pages/_includes/au-pd-practitionerrole-search.md
+++ b/pages/_includes/au-pd-practitionerrole-search.md
@@ -57,15 +57,15 @@ Chained search (via Practitioner) based on family, given and/or any name.
 -----------
 **Search: Provider Role**
 
-Search based on role.
+Search based on role code.
 
-`GET [base]/PractitionerRole?role=[system]|[code]`
+`GET [base]/PractitionerRole?code=[system]|[code]`
 
-*Example:* `GET [base]/PractitionerRole?role=http://snomed.info/sct|397897005`
+*Example:* `GET [base]/PractitionerRole?code=http://snomed.info/sct|397897005`
 
 *Support:*
 
-* MUST support search PractitionerRole by role.
+* MUST support search PractitionerRole by code.
 
 *Implementation Notes:* [(how to search by token)]
 


### PR DESCRIPTION
PractitionerRole?role=[system]|[code]

This seems incorrectly listed on http://hl7.org.au/fhir/pd/pd2/StructureDefinition-au-pd-practitionerrole.html as
GET [base]/PractitionerRole?code=[system]|[code]
should be
GET [base]/PractitionerRole?role=[system]|[code]