### PR TITLE
Mandate identifiers

### DIFF
--- a/input/examples/endpoint-example1.xml
+++ b/input/examples/endpoint-example1.xml
@@ -33,6 +33,10 @@
       <valueString value="L"/>
     </extension>
   </extension>
+  <identifier>
+    <system value="http://ns.electronichealth.net.au/smd/target"/>
+    <value value="http://ns.medicalobjects.com.au/smd/id/hostname/999999999XYZ"/>
+  </identifier>
   <status value="active"/>
   <connectionType>
     <system value="http://hl7.org.au/fhir/CodeSystem/smd-interfaces"/>

--- a/input/examples/healthcareservice-example0.xml
+++ b/input/examples/healthcareservice-example0.xml
@@ -5,6 +5,32 @@
 	<meta>
 		<profile value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-healthcareservice"/>
 	</meta>
+	<identifier>
+		<extension url="http://hl7.org.au/fhir/StructureDefinition/au-assigningauthority">
+			<extension url="namespace-id">
+				<valueString value="Medical-Objects"/>
+			</extension>
+			<extension url="universal-id">
+				<valueString value="33443682-91F6-11D2-8F2C-444553540123"/>
+			</extension>
+			<extension url="universal-id-type">
+				<valueString value="GUID"/>
+			</extension>
+		</extension>
+		<type>
+			<coding>
+				<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+				<code value="VDI"/>
+				<display value="Vendor Directory Identifier"/>
+			</coding>
+			<text value="Vendor Directory Identifier"/>
+		</type>
+		<system value="http://ns.medical-objects.com.au/id/routing-id"/>
+		<value value="BD6000000X9"/>
+		<assigner>
+			<display value="Medical-Objects"/>
+		</assigner>
+	</identifier>
 	<active value="true"/>
 	<providedBy>
 		<reference value="Organization/example0"/>

--- a/input/examples/location-example0.xml
+++ b/input/examples/location-example0.xml
@@ -5,6 +5,21 @@
 	<meta>
 		<profile value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-location"/>
 	</meta>
+	<identifier>
+		<type>
+			<coding>
+				<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+				<code value="LSPN"/>
+				<display value="Location Specific Practice Number"/>
+			</coding>
+			<text value="LSPN"/>
+		</type>
+		<system value="http://ns.electronichealth.net.au/id/location-specific-practice-number"/>
+		<!--In Australia LSPNs are an
+        incremental number that have been incremented to 5 digits, this example uses a fictional
+        LSPN from 100,000 + to ensure no conflict with real world values-->
+		<value value="123333"/>
+	</identifier>
 	<status value="active"/>
 	<name value="Downunder Hospital Blacktown"/>
 	<telecom>

--- a/input/examples/location-example0.xml
+++ b/input/examples/location-example0.xml
@@ -5,6 +5,21 @@
 	<meta>
 		<profile value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-location"/>
 	</meta>
+	<identifier>
+		<type>
+			<coding>
+				<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+				<code value="NATAS"/>
+				<display value="NATA Site Number"/>
+			</coding>
+			<text value="NATA Site Number"/>
+		</type>
+		<system value="http://hl7.org.au/id/nata-site"/>
+		<!--In Australia NATA numbers are an
+        incremental number that have been incremented to 5 digits, this example uses a fictional
+        NATA number from 100,000 + to ensure no conflict with real world values--> 
+		<value value="162899"/>
+	</identifier>
 	<status value="active"/>
 	<name value="Downunder Hospital Blacktown"/>
 	<telecom>

--- a/input/examples/location-example0.xml
+++ b/input/examples/location-example0.xml
@@ -5,21 +5,6 @@
 	<meta>
 		<profile value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-location"/>
 	</meta>
-	<identifier>
-		<type>
-			<coding>
-				<system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
-				<code value="NATAS"/>
-				<display value="NATA Site Number"/>
-			</coding>
-			<text value="NATA Site Number"/>
-		</type>
-		<system value="http://hl7.org.au/id/nata-site"/>
-		<!--In Australia NATA numbers are an
-        incremental number that have been incremented to 5 digits, this example uses a fictional
-        NATA number from 100,000 + to ensure no conflict with real world values--> 
-		<value value="162899"/>
-	</identifier>
 	<status value="active"/>
 	<name value="Downunder Hospital Blacktown"/>
 	<telecom>

--- a/input/examples/practitionerrole-example0.xml
+++ b/input/examples/practitionerrole-example0.xml
@@ -22,7 +22,7 @@
 			</coding>
 			<text value="Medicare Provider Number"/>
 		</type>
-		<system value="http://ns.electronichealth.net.au/id/provider-number"/>
+		<system value="http://ns.electronichealth.net.au/id/medicare-provider-number"/>
 		<value value="2426621B"/>
 	</identifier>
 	<identifier>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -93,6 +93,15 @@
       <description value="This profile defines a provider directory entry for a healthcare service or category of services delivered at a location by an organisation."/>
       <exampleBoolean value="false"/>
     </resource>
+    
+    <resource>
+      <reference>
+        <reference value="StructureDefinition/au-pd-vdi"/>
+      </reference>
+      <name value="AU VDI Identifier"/>
+      <description value="This profile defines a ... TO COMPLETE ... in an Australian context."/>
+      <exampleBoolean value="false"/>
+    </resource>
 
     <resource>
       <reference>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -96,6 +96,15 @@
     
     <resource>
       <reference>
+        <reference value="StructureDefinition/au-pd-smdtargetidentifier"/>
+      </reference>
+      <name value="PD Secure Messaging Delivery Target Identifier"/>
+      <description value="This identifier profile defines a secure messaging interface target identity in an Australian context."/>
+      <exampleBoolean value="false"/>
+    </resource>
+
+    <resource>
+      <reference>
         <reference value="StructureDefinition/au-pd-vdi"/>
       </reference>
       <name value="AU Vendor Directory Identifier"/>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -98,8 +98,8 @@
       <reference>
         <reference value="StructureDefinition/au-pd-vdi"/>
       </reference>
-      <name value="AU VDI Identifier"/>
-      <description value="This profile defines a ... TO COMPLETE ... in an Australian context."/>
+      <name value="AU Vendor Directory Identifier"/>
+      <description value="This identifier profile defines a vendor directory identifier in an Australian context."/>
       <exampleBoolean value="false"/>
     </resource>
 

--- a/input/intro-notes/StructureDefinition-au-pd-healthcareservice-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-healthcareservice-intro.md
@@ -5,7 +5,7 @@ In a provider directory this allows the association of endpoints with the health
 
 **Profile specific implementation guidance:**
 
-As a minimum, one of the following defined Identifier types **SHALL** be supplied:
+At least one of the following defined identifier types, known to this profile, **SHALL** be supplied:
 
 * [AU HPI-O](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-hpio.html)
 * [AU Residential Aged Care Service Identifier](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-residentialagedcareserviceidentifier.html)

--- a/input/intro-notes/StructureDefinition-au-pd-healthcareservice-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-healthcareservice-intro.md
@@ -1,3 +1,12 @@
 
 In a provider directory this allows the association of endpoints with the healthcare service and thus a channel for delivery to that service.
 
+### Usage Notes
+
+**Profile specific implementation guidance:**
+
+As a minimum, one of the following defined Identifier types **SHALL** be supplied:
+
+* [AU HPI-O](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-hpio.html)
+* [AU Residential Aged Care Service Identifier](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-residentialagedcareserviceidentifier.html)
+* [AU Vendor Directory Identifier](StructureDefinition-au-pd-vdi.html)

--- a/input/intro-notes/StructureDefinition-au-pd-location-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-location-intro.md
@@ -4,7 +4,7 @@ This profile defines the service delivery location by address at a minimum.
 
 **Profile specific implementation guidance:**
 
-As a minimum, one of the following defined Identifier types **SHOULD** be supplied:
+One of the following defined identifier types, known to this profile, **SHOULD** be supplied:
 
 * [AU Location Specific Practice Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-locationspecificpracticenumber.html)
 * [AU NATA Site Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-natasitenumber.html)

--- a/input/intro-notes/StructureDefinition-au-pd-location-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-location-intro.md
@@ -1,2 +1,10 @@
 This profile defines the service delivery location by address at a minimum.
 
+### Usage Notes
+
+**Profile specific implementation guidance:**
+
+As a minimum, one of the following defined Identifier types **SHALL** be supplied:
+
+* [AU Location Specific Practice Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-locationspecificpracticenumber.html)
+* [AU NATA Site Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-natasitenumber.html)

--- a/input/intro-notes/StructureDefinition-au-pd-location-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-location-intro.md
@@ -4,7 +4,7 @@ This profile defines the service delivery location by address at a minimum.
 
 **Profile specific implementation guidance:**
 
-As a minimum, one of the following defined Identifier types **SHALL** be supplied:
+As a minimum, one of the following defined Identifier types **SHOULD** be supplied:
 
 * [AU Location Specific Practice Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-locationspecificpracticenumber.html)
 * [AU NATA Site Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-natasitenumber.html)

--- a/input/intro-notes/StructureDefinition-au-pd-organisation-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-organisation-intro.md
@@ -8,7 +8,7 @@ As a minimum, one of the following defined Identifier types **SHALL** be supplie
 * [AU PAI-O Identifier](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-paioidentifier.html)
 * [AU CSP Registration Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-cspregistrationnumber.html)
 * [AU Australian Business Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-australianbusinessnumber.html)
-* [AU Australian Company Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-australiancompanynumber.html)AUAustralianCompanyNumber
+* [AU Australian Company Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-australiancompanynumber.html)
 * [AU Australian Registered Body Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-australianregistredbodynumber.html)
 * [AU NATA Accreditation Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-nataaccreditationnumber.html)
 * [AU Pharmacy Approval Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-pharmacyapprovalnumber.html)

--- a/input/intro-notes/StructureDefinition-au-pd-organisation-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-organisation-intro.md
@@ -2,7 +2,7 @@
 
 **Profile specific implementation guidance:**
 
-As a minimum, one of the following defined Identifier types **SHALL** be supplied:
+At least one of the following defined identifier types, known to this profile, **SHALL** be supplied:
 
 * [AU HPI-O](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-hpio.html)
 * [AU PAI-O Identifier](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-paioidentifier.html)

--- a/input/intro-notes/StructureDefinition-au-pd-organisation-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-organisation-intro.md
@@ -1,1 +1,14 @@
+### Usage Notes
 
+**Profile specific implementation guidance:**
+
+As a minimum, one of the following defined Identifier types **SHALL** be supplied:
+
+* [AU HPI-O](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-hpio.html)
+* [AU PAI-O Identifier](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-paioidentifier.html)
+* [AU CSP Registration Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-cspregistrationnumber.html)
+* [AU Australian Business Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-australianbusinessnumber.html)
+* [AU Australian Company Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-australiancompanynumber.html)AUAustralianCompanyNumber
+* [AU Australian Registered Body Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-australianregistredbodynumber.html)
+* [AU NATA Accreditation Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-nataaccreditationnumber.html)
+* [AU Pharmacy Approval Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-pharmacyapprovalnumber.html)

--- a/input/intro-notes/StructureDefinition-au-pd-practitioner-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-practitioner-intro.md
@@ -3,7 +3,7 @@
 
 **Profile specific implementation guidance:**
 
-As a minimum, one of the following defined Identifier types **SHALL** be supplied:
+At least one of the following defined identifier types, known to this profile, **SHALL** be supplied:
 
 * [AU HPI-I](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-hpii.html)
 * [AU PBS Prescriber Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-pbsprescribernumber.html)

--- a/input/intro-notes/StructureDefinition-au-pd-practitioner-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-practitioner-intro.md
@@ -1,3 +1,11 @@
 
+### Usage Notes
 
+**Profile specific implementation guidance:**
 
+As a minimum, one of the following defined Identifier types **SHALL** be supplied:
+
+* [AU HPI-I](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-hpii.html)
+* [AU PBS Prescriber Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-pbsprescribernumber.html)
+* [AU Care Agency Employee Identifier](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-careagencyemployeeidentifier.html)
+* [AU Ahpra Registration Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-ahpraregistrationnumber.html)

--- a/input/intro-notes/StructureDefinition-au-pd-practitionerrole-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-practitionerrole-intro.md
@@ -7,7 +7,7 @@ In the context of provider directories the practitioner role may include referen
 
 **Profile specific implementation guidance:**
 
-As a minimum, one of the following defined Identifier types **SHALL** be supplied:
+At least one of the following defined identifier types, known to this profile, **SHALL** be supplied:
 
 * [AU Medicare Provider Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-medicareprovidernumber.html)
 * [AU National Provider Identifier At Organisation](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-nationalprovideridentifieratorganisation.html)

--- a/input/intro-notes/StructureDefinition-au-pd-practitionerrole-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-practitionerrole-intro.md
@@ -3,10 +3,13 @@ The Australian profile for practitioner role is for a single healthcare service 
 
 In the context of provider directories the practitioner role may include references to endpoints that describe channels of communication to the provider in this role.
 
+### Usage Notes
 
+**Profile specific implementation guidance:**
 
+As a minimum, one of the following defined Identifier types **SHALL** be supplied:
 
-
-
-
-
+* [AU Medicare Provider Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-medicareprovidernumber.html)
+* [AU National Provider Identifier At Organisation](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-nationalprovideridentifieratorganisation.html)
+* [AU Employee Number](https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-employeenumber.html)
+* [AU Vendor Directory Identifier](StructureDefinition-au-pd-vdi.html)

--- a/input/intro-notes/StructureDefinition-au-pd-sm-endpoint-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-sm-endpoint-intro.md
@@ -1,2 +1,8 @@
 
+### Usage Notes
 
+**Profile specific implementation guidance:**
+
+As a minimum, one of the following defined Identifier types **SHALL** be supplied:
+
+* [PD Secure Messaging Delivery Target Identifier](StructureDefinition-au-pd-smdtargetidentifier.html)

--- a/input/intro-notes/StructureDefinition-au-pd-sm-endpoint-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-sm-endpoint-intro.md
@@ -3,6 +3,6 @@
 
 **Profile specific implementation guidance:**
 
-As a minimum, one of the following defined Identifier types **SHALL** be supplied:
+At least one of the following defined identifier types, known to this profile, **SHALL** be supplied:
 
 * [PD Secure Messaging Delivery Target Identifier](StructureDefinition-au-pd-smdtargetidentifier.html)

--- a/input/intro-notes/StructureDefinition-au-pd-smdtargetidentifier-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-smdtargetidentifier-intro.md
@@ -1,0 +1,2 @@
+### Usage Notes
+

--- a/input/intro-notes/StructureDefinition-au-pd-vdi-intro.md
+++ b/input/intro-notes/StructureDefinition-au-pd-vdi-intro.md
@@ -1,0 +1,2 @@
+### Usage Notes
+

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -36,7 +36,7 @@ To help implementers, only the more significant changes are listed here.
                     <li><code>type.text</code> value is no longer mandatory</li>
                 </ul>            
             </li>
-            <li>the identifier slice discriminator has been updated to be <code>pattern:type</code>
+            <li>the identifier slice discriminator has been updated to be <code>pattern:type</code></li>
             <li>the inheritance from the updated AU Base HealthcareService includes explicit Identifier types for all of the applicable organisation identifiers (i.e. HPI-O and AU Residential Aged Care Service Identifier)</li>
             <li>the inheritance from the updated AU Base HealthcareService allows the <a href="http://hl7.org.au/fhir/4.1.0/StructureDefinition-au-assigningauthority.html">HL7 V2 Assigning Authority Identifier extension</a> on all Identifier slices</li>
             <li>the inheritance from the updated AU Base HealthcareService introduces the <a href="http://hl7.org.au/fhir/4.1.0/StructureDefinition-identifier-routability.html">Identifier Routability Identifier extension</a> on all Identifier slices</li>
@@ -108,7 +108,7 @@ To help implementers, only the more significant changes are listed here.
             <li>concepts no longer have a nested hierarchy</li>
         </ul>
     </li>
-    <li>Examples: </a>
+    <li>Examples:
         <ul>
             <li><a href="HealthcareService-example0.html">healthcareservice-example0.xml</a>: added a snippet of the AU Vendor Directory Identifier</li>
             <li><a href="PractitionerRole-example0.html">practitionerrole-example0.xml</a>: corrected wrong system value for Medicare Provider Number identifier</li>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -15,10 +15,28 @@ To help implementers, only the more significant changes are listed here.
         <ul>
             <li>Changed <a href="http://hl7.org.au/fhir/4.1.0/CodeSystem-au-location-physical-type.html">Location Type (Physical) AU</a> to deprecate concept 'vi'. This code has been deprecated as it has been replaced by an equivalent term provided by HL7 international.</li>
         </ul>
-    </li>    
+    </li>
+    <li>Profile: <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> - <strong>new</strong>
+        <ul>
+            <li>refactored from the in-line Identifier definitions in <a href="StructureDefinition-au-pd-healthcareservice.html">AU PD Healthcare Service</a> and <a href="StructureDefinition-au-pd-practitionerrole.html">AU PD Practitioner Role</a>, thereby amalgamating the respective definitions into a single datatype profile</li>
+            <li>constraints follow other HL7AU Base IG Identifier profiles, such as using `patternCodeableConcept` for `type.coding`, and not mandating type.text</li>
+        </ul>
+    </li>
+    <li>Profile: <a href="StructureDefinition-au-pd-smdtargetidentifier.html">PD Secure Messaging Delivery Target Identifier</a> - <strong>new</strong>
+        <ul>
+            <li>refactored from the in-line Identifier definitions in <a href="StructureDefinition-au-pd-sm-endpoint.html">AU PD Secure Messaging Endpoint</a></li>
+        </ul>
+    </li>
     <li>Profile: <a href="StructureDefinition-au-pd-healthcareservice.html">AU PD Healthcare Service</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>removed in-line identifier definitions for <code>pdvendor</code> and instead references the new <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> profile. The impact of this change is that 
+                <ul>
+                    <li><code>type.coding.system</code> value is now <code>http://terminology.hl7.org.au/CodeSystem/v2-0203</code> (instead of <code>http://terminology.hl7.org/CodeSystem/v2-0203</code>) - <strong>breaking change</strong></li>
+                    <li><code>type.text</code> value is no longer mandatory</li>
+                </ul>            
+            </li>
+            <li>the identifier slice discriminator has been updated to be <code>pattern:type</code>
             <li>the inheritance from the updated AU Base HealthcareService includes explicit Identifier types for all of the applicable organisation identifiers (i.e. HPI-O and AU Residential Aged Care Service Identifier)</li>
             <li>the inheritance from the updated AU Base HealthcareService allows the <a href="http://hl7.org.au/fhir/4.1.0/StructureDefinition-au-assigningauthority.html">HL7 V2 Assigning Authority Identifier extension</a> on all Identifier slices</li>
             <li>the inheritance from the updated AU Base HealthcareService introduces the <a href="http://hl7.org.au/fhir/4.1.0/StructureDefinition-identifier-routability.html">Identifier Routability Identifier extension</a> on all Identifier slices</li>
@@ -29,6 +47,7 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-location.html">AU PD Location</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>Location.identifier is now must support = true</li>
             <li>the inheritance from the updated AU Base Location includes <a href="http://hl7.org.au/fhir/4.1.0/StructureDefinition-au-address.html">AustralianAddress</a> as an allowed Location.address type </li>
             <li>the inheritance from the updated AU Base Location includes <a href="http://hl7.org.au/fhir/4.1.0/StructureDefinition-au-locationspecificpracticenumber.html">AU Location Specific Practice Number</a> as an allowed Location.identifier type </li>
         </ul>
@@ -36,18 +55,32 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-organisation.html">AU PD Organisation</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>the slicing discriminator on Organization.identifier is now <code>pattern:type</code></li>
+            <li>Organization.identifier is now must support = true</li>
             <li>the inheritance from the updated AU Base Organisation includes explicit Identifier types for all of the applicable organisation identifiers (i.e. HPI-O, ACN, ABN etc)</li>       
         </ul>
     </li>
     <li>Profile: <a href="StructureDefinition-au-pd-practitioner.html">AU PD Practitioner</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>the Practitioner.identifier element has been updated to have slicing discriminator of <code>pattern:type</code>, must support = true and the HPI-I identifier datatype profile properly referenced</li>
             <li>the inheritance from the updated AU Base Practitioner includes explicit Identifier types for all of the applicable practitioner identifiers (i.e. HPI-I, PBS prescriber number etc)</li>
         </ul>
     </li>
     <li>Profile: <a href="StructureDefinition-au-pd-practitionerrole.html">AU PD Practitioner Role</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>removed in-line identifier definitions for <code>vendorAssignedDirectoryIdentifier</code> and instead references the new <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> profile. The impact of this change is that 
+                <ul>
+                    <li><code>type</code> value is now mandatory - <strong>breaking change</strong></li>
+                    <li><code>type.coding.system</code> is now mandatory with a fixed value of <code>http://terminology.hl7.org.au/CodeSystem/v2-0203</code> - <strong>breaking change</strong></li>
+                    <li><code>type.coding.code</code> is now mandatory - <strong>breaking change</strong></li>
+                    <li><code>type.text</code> value is no longer mandatory</li>
+                    <li><code>system</code> is now mandatory - <strong>breaking change</strong></li>
+                    <li><code>value</code> is now mandatory - <strong>breaking change</strong></li>
+                </ul>            
+            </li>
+            <li>the identifier slice discriminator has been updated to be <code>pattern:type</code></li>
             <li>the inheritance from the updated AU Base PractitionerRole includes explicit Identifier types for all of the applicable practitioner role identifiers (i.e. Medicare provider number, National Provider Identifier At Organisation etc)</li>
             <li>the inheritance from the updated AU Base PractitionerRole allows the <a href="http://hl7.org.au/fhir/4.1.0/StructureDefinition-au-assigningauthority.html">HL7 V2 Assigning Authority Identifier extension</a> on all Identifier slices</li>
             <li>the inheritance from the updated AU Base PractitionerRole introduces the <a href="http://hl7.org.au/fhir/4.1.0/StructureDefinition-identifier-routability.html">Identifier Routability Identifier extension</a> on all Identifier slices</li>
@@ -59,6 +92,9 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-sm-endpoint.html">AU PD Secure Messaging Endpoint</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>removed in-line identifier definitions for <code>smdtarget</code> and instead references the new <a href="StructureDefinition-au-pd-smdtargetidentifier.html">PD Secure Messaging Delivery Target Identifier</a> profile. This update does not involve any constraint changes.</li>
+            <li>the identifier slice discriminator has been updated to be <code>pattern:type</code></li>
+            <li>Endpoint.identifier is now must support = true</li>
         </ul>
     </li>
     <li>ValueSet: <a href="ValueSet-service-interfaces.html">Australian Service Interfaces</a>
@@ -70,6 +106,12 @@ To help implementers, only the more significant changes are listed here.
         <ul>
             <li>4 concepts were added for HL7 v2.4 ORU, ORM, ORR and ACK messages</li>
             <li>concepts no longer have a nested hierarchy</li>
+        </ul>
+    </li>
+    <li>Examples: </a>
+        <ul>
+            <li><a href="HealthcareService-example0.html">healthcareservice-example0.xml</a>: added a snippet of the AU Vendor Directory Identifier</li>
+            <li><a href="PractitionerRole-example0.html">practitionerrole-example0.xml</a>: corrected wrong system value for Medicare Provider Number identifier</li>
         </ul>
     </li>
     <li>Guidance page

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -19,7 +19,7 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> - <strong>new</strong>
         <ul>
             <li>refactored from the in-line Identifier definitions in <a href="StructureDefinition-au-pd-healthcareservice.html">AU PD Healthcare Service</a> and <a href="StructureDefinition-au-pd-practitionerrole.html">AU PD Practitioner Role</a>, thereby amalgamating the respective definitions into a single datatype profile</li>
-            <li>constraints follow other HL7AU Base IG Identifier profiles, such as using `patternCodeableConcept` for `type.coding`, and not mandating type.text</li>
+            <li>constraints follow other HL7AU Base IG Identifier profiles, such as using <code>patternCodeableConcept</code> for <code>type.coding</code>, and not mandating <code>type.text</code></li>
         </ul>
     </li>
     <li>Profile: <a href="StructureDefinition-au-pd-smdtargetidentifier.html">PD Secure Messaging Delivery Target Identifier</a> - <strong>new</strong>
@@ -30,7 +30,7 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-healthcareservice.html">AU PD Healthcare Service</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
-            <li>removed in-line identifier definitions for <code>pdvendor</code> and instead references the new <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> profile. The impact of this change is that 
+            <li>removed in-line identifier definitions for <code>pdvendor</code> and instead reference the new <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> profile. The impact of this change on representations of vendor directory identifiers is that:
                 <ul>
                     <li><code>type.coding.system</code> value is now <code>http://terminology.hl7.org.au/CodeSystem/v2-0203</code> (instead of <code>http://terminology.hl7.org/CodeSystem/v2-0203</code>) - <strong>breaking change</strong></li>
                     <li><code>type.text</code> value is no longer mandatory</li>
@@ -70,7 +70,7 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-practitionerrole.html">AU PD Practitioner Role</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
-            <li>removed in-line identifier definitions for <code>vendorAssignedDirectoryIdentifier</code> and instead references the new <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> profile. The impact of this change is that 
+            <li>removed in-line identifier definitions for <code>vendorAssignedDirectoryIdentifier</code> and instead reference the new <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> profile. The impact of this change on representations of vendor directory identifiers is that:
                 <ul>
                     <li><code>type</code> value is now mandatory - <strong>breaking change</strong></li>
                     <li><code>type.coding.system</code> is now mandatory with a fixed value of <code>http://terminology.hl7.org.au/CodeSystem/v2-0203</code> - <strong>breaking change</strong></li>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -30,6 +30,7 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-healthcareservice.html">AU PD Healthcare Service</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>mandated at least one of the known and defined Identifier types (invariant <code>au-pd-hs-01</code>), i.e. <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-hpio.html">AU HPI-O</a>, <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-residentialagedcareserviceidentifier.html">AU Residential Aged Care Service Identifier</a> or <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> - <strong>breaking change</strong></li>
             <li>removed in-line identifier definitions for <code>pdvendor</code> and instead reference the new <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> profile. The impact of this change on representations of vendor directory identifiers is that:
                 <ul>
                     <li><code>type.coding.system</code> value is now <code>http://terminology.hl7.org.au/CodeSystem/v2-0203</code> (instead of <code>http://terminology.hl7.org/CodeSystem/v2-0203</code>) - <strong>breaking change</strong></li>
@@ -47,6 +48,7 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-location.html">AU PD Location</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>at least one of the known and defined Identifier types should be present (invariant <code>au-pd-loc-01</code>), i.e. <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-locationspecificpracticenumber.html">AU Location Specific Practice Number</a> or <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-natasitenumber.html">AU NATA Site Number</a></li>
             <li>Location.identifier is now must support = true</li>
             <li>the inheritance from the updated AU Base Location includes <a href="http://hl7.org.au/fhir/4.1.0/StructureDefinition-au-address.html">AustralianAddress</a> as an allowed Location.address type </li>
             <li>the inheritance from the updated AU Base Location includes <a href="http://hl7.org.au/fhir/4.1.0/StructureDefinition-au-locationspecificpracticenumber.html">AU Location Specific Practice Number</a> as an allowed Location.identifier type </li>
@@ -55,6 +57,8 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-organisation.html">AU PD Organisation</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>mandated at least one of the known and defined Identifier types (invariant <code>au-pd-org-01</code>), i.e. <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-hpio.html">AU HPI-O</a>, <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-paioidentifier.html">AU PAI-O Identifier</a>, <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-cspregistrationnumber.html">AU CSP Registration Number</a>, <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-australianbusinessnumber.html">AU Australian Business Number</a>, <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-australiancompanynumber.html">AU Australian Company Number</a>, <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-australianregistredbodynumber.html">AU Australian Registered Body Number</a>, <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-nataaccreditationnumber.html">AU NATA Accreditation Number</a> or <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-pharmacyapprovalnumber.html">AU Pharmacy Approval Number</a>
+ - <strong>breaking change</strong></li>
             <li>the slicing discriminator on Organization.identifier is now <code>pattern:type</code></li>
             <li>Organization.identifier is now must support = true</li>
             <li>the inheritance from the updated AU Base Organisation includes explicit Identifier types for all of the applicable organisation identifiers (i.e. HPI-O, ACN, ABN etc)</li>       
@@ -63,6 +67,7 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-practitioner.html">AU PD Practitioner</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>mandated at least one of the known and defined Identifier types (invariant <code>au-pd-prac-01</code>), i.e. <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-hpii.html">AU HPI-I</a>, <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-pbsprescribernumber.html">AU PBS Prescriber Number</a>, <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-careagencyemployeeidentifier.html">AU Care Agency Employee Identifier</a> or<a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-ahpraregistrationnumber.html">AU Ahpra Registration Number</a> - <strong>breaking change</strong></li>
             <li>the Practitioner.identifier element has been updated to have slicing discriminator of <code>pattern:type</code>, must support = true and the HPI-I identifier datatype profile properly referenced</li>
             <li>the inheritance from the updated AU Base Practitioner includes explicit Identifier types for all of the applicable practitioner identifiers (i.e. HPI-I, PBS prescriber number etc)</li>
         </ul>
@@ -70,6 +75,7 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-practitionerrole.html">AU PD Practitioner Role</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>mandated at least one of the known and defined Identifier types (invariant <code>au-pd-pracrole-01</code>), i.e. <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-medicareprovidernumber.html">AU Medicare Provider Number</a>, <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-nationalprovideridentifieratorganisation.html">AU National Provider Identifier At Organisation</a>, <a href="https://hl7.org.au/fhir/4.1.0/StructureDefinition-au-employeenumber.html">AU Employee Number</a> or <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> - <strong>breaking change</strong></li>
             <li>removed in-line identifier definitions for <code>vendorAssignedDirectoryIdentifier</code> and instead reference the new <a href="StructureDefinition-au-pd-vdi.html">AU Vendor Directory Identifier</a> profile. The impact of this change on representations of vendor directory identifiers is that:
                 <ul>
                     <li><code>type</code> value is now mandatory - <strong>breaking change</strong></li>
@@ -92,6 +98,7 @@ To help implementers, only the more significant changes are listed here.
     <li>Profile: <a href="StructureDefinition-au-pd-sm-endpoint.html">AU PD Secure Messaging Endpoint</a>
         <ul>
             <li>based on FHIR version 4.0.1 instead of 4.0.0</li>
+            <li>mandated at least one of the known and defined Identifier types (invariant <code>au-pd-ep-01</code>), i.e. <a href="StructureDefinition-au-pd-smdtargetidentifier.html">PD Secure Messaging Delivery Target Identifier</a> - <strong>breaking change</strong></li>
             <li>removed in-line identifier definitions for <code>smdtarget</code> and instead references the new <a href="StructureDefinition-au-pd-smdtargetidentifier.html">PD Secure Messaging Delivery Target Identifier</a> profile. This update does not involve any constraint changes.</li>
             <li>the identifier slice discriminator has been updated to be <code>pattern:type</code></li>
             <li>Endpoint.identifier is now must support = true</li>

--- a/input/resources/au-pd-healthcareservice.xml
+++ b/input/resources/au-pd-healthcareservice.xml
@@ -36,6 +36,7 @@
         </discriminator>
         <rules value="open" />
       </slicing>
+      <min value="1"/>
       <mustSupport value="true" />
     </element>
     <element id="HealthcareService.identifier.extension">

--- a/input/resources/au-pd-healthcareservice.xml
+++ b/input/resources/au-pd-healthcareservice.xml
@@ -31,7 +31,7 @@
       <path value="HealthcareService.identifier" />
       <slicing>
         <discriminator>
-          <type value="pattern" />
+          <type value="value" />
           <path value="type" />
         </discriminator>
         <rules value="open" />

--- a/input/resources/au-pd-healthcareservice.xml
+++ b/input/resources/au-pd-healthcareservice.xml
@@ -31,7 +31,7 @@
       <path value="HealthcareService.identifier" />
       <slicing>
         <discriminator>
-          <type value="value" />
+          <type value="pattern" />
           <path value="type" />
         </discriminator>
         <rules value="open" />

--- a/input/resources/au-pd-healthcareservice.xml
+++ b/input/resources/au-pd-healthcareservice.xml
@@ -22,7 +22,7 @@
         <key value="au-pd-hs-01"/>
         <severity value="error"/>
         <human value="At least one defined identifier, known to this AU PD Healthcare Service profile, must be present"/>
-        <expression value="identifier.where(type.coding.code='VDI' or system='http://ns.electronichealth.net.au/id/hi/hpio/1.0' or system='http://ns.electronichealth.net.au/id/residential-aged-care-service-id').exists()"/>
+        <expression value="identifier.exists() implies identifier.where(type.coding.code='VDI' or system='http://ns.electronichealth.net.au/id/hi/hpio/1.0' or system='http://ns.electronichealth.net.au/id/residential-aged-care-service-id').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-healthcareservice"/>
       </constraint>
     </element>

--- a/input/resources/au-pd-healthcareservice.xml
+++ b/input/resources/au-pd-healthcareservice.xml
@@ -21,7 +21,7 @@
       <constraint>
         <key value="au-pd-hs-01"/>
         <severity value="error"/>
-        <human value="At least a known and defined identifier must be present"/>
+        <human value="At least one defined identifier, known to this AU PD Healthcare Service profile, must be present"/>
         <expression value="identifier.where(type.coding.code='VDI' or system='http://ns.electronichealth.net.au/id/hi/hpio/1.0' or system='http://ns.electronichealth.net.au/id/residential-aged-care-service-id').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-healthcareservice"/>
       </constraint>

--- a/input/resources/au-pd-healthcareservice.xml
+++ b/input/resources/au-pd-healthcareservice.xml
@@ -34,10 +34,6 @@
           <type value="pattern" />
           <path value="type" />
         </discriminator>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
         <rules value="open" />
       </slicing>
       <mustSupport value="true" />

--- a/input/resources/au-pd-healthcareservice.xml
+++ b/input/resources/au-pd-healthcareservice.xml
@@ -18,6 +18,13 @@
       </extension>
       <path value="HealthcareService" />
       <definition value="Directory entry for a healthcare service at a location by an organisation." />
+      <constraint>
+        <key value="au-pd-hs-01"/>
+        <severity value="error"/>
+        <human value="At least a known and defined identifier must be present"/>
+        <expression value="identifier.where(type.coding.code='VDI' or system='http://ns.electronichealth.net.au/id/hi/hpio/1.0' or system='http://ns.electronichealth.net.au/id/residential-aged-care-service-id').exists()"/>
+        <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-healthcareservice"/>
+      </constraint>
     </element>
     <element id="HealthcareService.meta">
       <path value="HealthcareService.meta" />

--- a/input/resources/au-pd-healthcareservice.xml
+++ b/input/resources/au-pd-healthcareservice.xml
@@ -77,9 +77,9 @@
       </type>
       <mustSupport value="true" />
     </element>
-    <element id="HealthcareService.identifier:pdvendor">
+    <element id="HealthcareService.identifier:auvdi">
       <path value="HealthcareService.identifier" />
-      <sliceName value="pdvendor" />
+      <sliceName value="auvdi" />
       <short value="Secure Messaging Vendor's Healthcare Service Identifier" />
       <definition value="Vendor allocated directory identifier this can be used for search for specific healthcare service directory entry and/or for routing of messages." />
       <type>

--- a/input/resources/au-pd-healthcareservice.xml
+++ b/input/resources/au-pd-healthcareservice.xml
@@ -88,66 +88,9 @@
       <definition value="Vendor allocated directory identifier this can be used for search for specific healthcare service directory entry and/or for routing of messages." />
       <type>
         <code value="Identifier" />
-        <profile value="http://hl7.org/fhir/StructureDefinition/Identifier" />
+        <profile value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-vdi" />
       </type>
       <mustSupport value="true" />
-    </element>
-    <element id="HealthcareService.identifier:pdvendor.type">
-      <path value="HealthcareService.identifier.type" />
-      <short value="Vendor Directory Identifier Type" />
-      <definition value="Element describing the type of identifier" />
-      <min value="1" />
-      <binding>
-        <strength value="required" />
-        <description value="Local Identifier Type" />
-        <valueSet value="http://terminology.hl7.org/ValueSet/v2-0203" />
-      </binding>
-    </element>
-    <element id="HealthcareService.identifier:pdvendor.type.coding">
-      <path value="HealthcareService.identifier.type.coding" />
-      <short value="Vendor Directory Identifier" />
-      <definition value="Type code for vendor directory identifier" />
-      <min value="1" />
-      <max value="1" />
-    </element>
-    <element id="HealthcareService.identifier:pdvendor.type.coding.system">
-      <path value="HealthcareService.identifier.type.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://terminology.hl7.org/CodeSystem/v2-0203" />
-    </element>
-    <element id="HealthcareService.identifier:pdvendor.type.coding.code">
-      <path value="HealthcareService.identifier.type.coding.code" />
-      <min value="1" />
-      <fixedCode value="VDI" />
-    </element>
-    <element id="HealthcareService.identifier:pdvendor.type.text">
-      <path value="HealthcareService.identifier.type.text" />
-      <short value="Vendor Directory Identifier Type" />
-      <definition value="Vendor Directory Identifier type description" />
-      <min value="1" />
-      <fixedString value="Vendor Directory Identifier" />
-    </element>
-    <element id="HealthcareService.identifier:pdvendor.system">
-      <path value="HealthcareService.identifier.system" />
-      <short value="Vendor allocated URL" />
-      <definition value="Unique namespace for the assigning vendor's identifier value." />
-      <min value="1" />
-    </element>
-    <element id="HealthcareService.identifier:pdvendor.value">
-      <path value="HealthcareService.identifier.value" />
-      <short value="Vendor Identifier Value" />
-      <definition value="Assigning vendor's identifier value." />
-      <min value="1" />
-    </element>
-    <element id="HealthcareService.identifier:pdvendor.assigner">
-      <path value="HealthcareService.identifier.assigner" />
-      <short value="Secure messaging vendor organisation" />
-      <min value="1" />
-    </element>
-    <element id="HealthcareService.identifier:pdvendor.assigner.display">
-      <path value="HealthcareService.identifier.assigner.display" />
-      <short value="Secure messaging vendor organisation name" />
-      <min value="1" />
     </element>
     <element id="HealthcareService.active">
       <path value="HealthcareService.active" />

--- a/input/resources/au-pd-location.xml
+++ b/input/resources/au-pd-location.xml
@@ -29,6 +29,7 @@
     </element>
     <element id="Location.identifier">
       <path value="Location.identifier"/>
+      <min value="1"/>
       <mustSupport value="true"/>
     </element>
     <element id="Location.status">

--- a/input/resources/au-pd-location.xml
+++ b/input/resources/au-pd-location.xml
@@ -21,7 +21,7 @@
       <constraint>
         <key value="au-pd-loc-01"/>
         <severity value="warning"/>
-        <human value="At least one defined identifier, known to this AU PD Location profile, must be present"/>
+        <human value="At least one defined identifier, known to this AU PD Location profile, should be present"/>
         <expression value="identifier.exists() implies identifier.where(system='http://ns.electronichealth.net.au/id/location-specific-practice-number' or system='http://hl7.org.au/id/nata-site').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-location"/>
       </constraint>

--- a/input/resources/au-pd-location.xml
+++ b/input/resources/au-pd-location.xml
@@ -22,7 +22,7 @@
         <key value="au-pd-loc-01"/>
         <severity value="warning"/>
         <human value="At least one defined identifier, known to this AU PD Location profile, must be present"/>
-        <expression value="identifier.where(system='http://ns.electronichealth.net.au/id/location-specific-practice-number' or system='http://hl7.org.au/id/nata-site').exists()"/>
+        <expression value="identifier.exists() implies identifier.where(system='http://ns.electronichealth.net.au/id/location-specific-practice-number' or system='http://hl7.org.au/id/nata-site').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-location"/>
       </constraint>
     </element>

--- a/input/resources/au-pd-location.xml
+++ b/input/resources/au-pd-location.xml
@@ -20,8 +20,8 @@
       <short value="Australian Location Directory Entry" />
       <constraint>
         <key value="au-pd-loc-01"/>
-        <severity value="error"/>
-        <human value="At least a known and defined identifier must be present"/>
+        <severity value="warning"/>
+        <human value="At least a known and defined identifier should be present"/>
         <expression value="identifier.where(system='http://ns.electronichealth.net.au/id/location-specific-practice-number' or system='http://hl7.org.au/id/nata-site').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-location"/>
       </constraint>

--- a/input/resources/au-pd-location.xml
+++ b/input/resources/au-pd-location.xml
@@ -21,7 +21,7 @@
       <constraint>
         <key value="au-pd-loc-01"/>
         <severity value="warning"/>
-        <human value="At least a known and defined identifier should be present"/>
+        <human value="At least one defined identifier, known to this AU PD Location profile, must be present"/>
         <expression value="identifier.where(system='http://ns.electronichealth.net.au/id/location-specific-practice-number' or system='http://hl7.org.au/id/nata-site').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-location"/>
       </constraint>

--- a/input/resources/au-pd-location.xml
+++ b/input/resources/au-pd-location.xml
@@ -27,6 +27,10 @@
       <path value="Location.meta.source" />
       <mustSupport value="true" />
     </element>
+    <element id="Location.identifier">
+      <path value="Location.identifier"/>
+      <mustSupport value="true"/>
+    </element>
     <element id="Location.status">
       <path value="Location.status" />
       <short value="Required status" />

--- a/input/resources/au-pd-location.xml
+++ b/input/resources/au-pd-location.xml
@@ -18,6 +18,13 @@
       </extension>
       <path value="Location" />
       <short value="Australian Location Directory Entry" />
+      <constraint>
+        <key value="au-pd-loc-01"/>
+        <severity value="error"/>
+        <human value="At least a known and defined identifier must be present"/>
+        <expression value="identifier.where(system='http://ns.electronichealth.net.au/id/location-specific-practice-number' or system='http://hl7.org.au/id/nata-site').exists()"/>
+        <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-location"/>
+      </constraint>
     </element>
     <element id="Location.meta">
       <path value="Location.meta" />

--- a/input/resources/au-pd-organisation.xml
+++ b/input/resources/au-pd-organisation.xml
@@ -22,7 +22,7 @@
       <constraint>
         <key value="au-pd-org-01"/>
         <severity value="error"/>
-        <human value="At least a known and defined identifier must be present"/>
+        <human value="At least one defined identifier, known to this AU PD Organisation profile, must be present"/>
         <expression value="identifier.where(system='http://ns.electronichealth.net.au/id/hi/hpio/1.0' or system='http://ns.electronichealth.net.au/id/pcehr/paio/1.0' or system='http://ns.electronichealth.net.au/id/hi/csp/1.0' or system='http://hl7.org.au/id/abn' or system='http://hl7.org.au/id/acn' or system='http://hl7.org.au/id/arbn' or system='http://hl7.org.au/id/nata-accreditation' or system='http://ns.electronichealth.net.au/id/pharmacy-approval-number').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-organisation"/>
       </constraint>

--- a/input/resources/au-pd-organisation.xml
+++ b/input/resources/au-pd-organisation.xml
@@ -33,7 +33,7 @@
       <slicing>
         <discriminator>
           <type value="value" />
-          <path value="type" />
+          <path value="system" />
         </discriminator>
         <rules value="open" />
       </slicing>

--- a/input/resources/au-pd-organisation.xml
+++ b/input/resources/au-pd-organisation.xml
@@ -32,8 +32,8 @@
       <path value="Organization.identifier" />
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="pattern" />
+          <path value="type" />
         </discriminator>
         <rules value="open" />
       </slicing>

--- a/input/resources/au-pd-organisation.xml
+++ b/input/resources/au-pd-organisation.xml
@@ -19,6 +19,13 @@
       <path value="Organization" />
       <short value="Australian Organisation Directory Entry" />
       <definition value="Directory entry Australian realm Organisation profile often healthcare or related service provision." />
+      <constraint>
+        <key value="au-pd-org-01"/>
+        <severity value="error"/>
+        <human value="At least a known and defined identifier must be present"/>
+        <expression value="identifier.where(system='http://ns.electronichealth.net.au/id/hi/hpio/1.0' or system='http://ns.electronichealth.net.au/id/pcehr/paio/1.0' or system='http://ns.electronichealth.net.au/id/hi/csp/1.0' or system='http://hl7.org.au/id/abn' or system='http://hl7.org.au/id/acn' or system='http://hl7.org.au/id/arbn' or system='http://hl7.org.au/id/nata-accreditation' or system='http://ns.electronichealth.net.au/id/pharmacy-approval-number').exists()"/>
+        <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-organisation"/>
+      </constraint>
     </element>
     <element id="Organization.meta">
       <path value="Organization.meta" />

--- a/input/resources/au-pd-organisation.xml
+++ b/input/resources/au-pd-organisation.xml
@@ -38,6 +38,7 @@
         <rules value="open" />
       </slicing>
       <short value="Organisation Directory Entry Identifiers" />
+      <min value="1"/>
       <mustSupport value="true" />
     </element>
     <element id="Organization.identifier:hpio">

--- a/input/resources/au-pd-organisation.xml
+++ b/input/resources/au-pd-organisation.xml
@@ -32,7 +32,7 @@
       <path value="Organization.identifier" />
       <slicing>
         <discriminator>
-          <type value="pattern" />
+          <type value="value" />
           <path value="type" />
         </discriminator>
         <rules value="open" />

--- a/input/resources/au-pd-organisation.xml
+++ b/input/resources/au-pd-organisation.xml
@@ -38,6 +38,7 @@
         <rules value="open" />
       </slicing>
       <short value="Organisation Directory Entry Identifiers" />
+      <mustSupport value="true" />
     </element>
     <element id="Organization.identifier:hpio">
       <path value="Organization.identifier" />

--- a/input/resources/au-pd-organisation.xml
+++ b/input/resources/au-pd-organisation.xml
@@ -23,7 +23,7 @@
         <key value="au-pd-org-01"/>
         <severity value="error"/>
         <human value="At least one defined identifier, known to this AU PD Organisation profile, must be present"/>
-        <expression value="identifier.where(system='http://ns.electronichealth.net.au/id/hi/hpio/1.0' or system='http://ns.electronichealth.net.au/id/pcehr/paio/1.0' or system='http://ns.electronichealth.net.au/id/hi/csp/1.0' or system='http://hl7.org.au/id/abn' or system='http://hl7.org.au/id/acn' or system='http://hl7.org.au/id/arbn' or system='http://hl7.org.au/id/nata-accreditation' or system='http://ns.electronichealth.net.au/id/pharmacy-approval-number').exists()"/>
+        <expression value="identifier.exists() implies identifier.where(system='http://ns.electronichealth.net.au/id/hi/hpio/1.0' or system='http://ns.electronichealth.net.au/id/pcehr/paio/1.0' or system='http://ns.electronichealth.net.au/id/hi/csp/1.0' or system='http://hl7.org.au/id/abn' or system='http://hl7.org.au/id/acn' or system='http://hl7.org.au/id/arbn' or system='http://hl7.org.au/id/nata-accreditation' or system='http://ns.electronichealth.net.au/id/pharmacy-approval-number').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-organisation"/>
       </constraint>
     </element>

--- a/input/resources/au-pd-practitioner.xml
+++ b/input/resources/au-pd-practitioner.xml
@@ -32,7 +32,7 @@
       <path value="Practitioner.identifier" />
       <slicing>
         <discriminator>
-          <type value="pattern" />
+          <type value="value" />
           <path value="type" />
         </discriminator>
         <rules value="open" />

--- a/input/resources/au-pd-practitioner.xml
+++ b/input/resources/au-pd-practitioner.xml
@@ -22,7 +22,7 @@
       <constraint>
         <key value="au-pd-prac-01"/>
         <severity value="error"/>
-        <human value="At least a known and defined identifier must be present"/>
+        <human value="At least one defined identifier, known to this AU PD Practitioner profile, must be present"/>
         <expression value="identifier.where(system='http://ns.electronichealth.net.au/id/hi/hpii/1.0' or system='http://ns.electronichealth.net.au/id/medicare-prescriber-number' or system='http://ns.electronichealth.net.au/id/pcehr/caei/1.0' or system='http://hl7.org.au/id/ahpra-registration-number').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-practitioner"/>
       </constraint>

--- a/input/resources/au-pd-practitioner.xml
+++ b/input/resources/au-pd-practitioner.xml
@@ -19,6 +19,13 @@
       <path value="Practitioner" />
       <short value="Australian Practitioner Directory Entry" />
       <definition value="Directory entry for a person who is directly or indirectly involved in the provisioning of healthcare." />
+      <constraint>
+        <key value="au-pd-prac-01"/>
+        <severity value="error"/>
+        <human value="At least a known and defined identifier must be present"/>
+        <expression value="identifier.where(system='http://ns.electronichealth.net.au/id/hi/hpii/1.0' or system='http://ns.electronichealth.net.au/id/medicare-prescriber-number' or system='http://ns.electronichealth.net.au/id/pcehr/caei/1.0' or system='http://hl7.org.au/id/ahpra-registration-number').exists()"/>
+        <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-practitioner"/>
+      </constraint>
     </element>
     <element id="Practitioner.meta">
       <path value="Practitioner.meta" />

--- a/input/resources/au-pd-practitioner.xml
+++ b/input/resources/au-pd-practitioner.xml
@@ -28,6 +28,16 @@
       <path value="Practitioner.meta.source" />
       <mustSupport value="true" />
     </element>
+    <element id="Practitioner.identifier">
+      <path value="Practitioner.identifier" />
+      <slicing>
+        <discriminator>
+          <type value="pattern" />
+          <path value="type" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
     <element id="Practitioner.identifier:hpii">
       <path value="Practitioner.identifier" />
       <sliceName value="hpii" />

--- a/input/resources/au-pd-practitioner.xml
+++ b/input/resources/au-pd-practitioner.xml
@@ -23,7 +23,7 @@
         <key value="au-pd-prac-01"/>
         <severity value="error"/>
         <human value="At least one defined identifier, known to this AU PD Practitioner profile, must be present"/>
-        <expression value="identifier.where(system='http://ns.electronichealth.net.au/id/hi/hpii/1.0' or system='http://ns.electronichealth.net.au/id/medicare-prescriber-number' or system='http://ns.electronichealth.net.au/id/pcehr/caei/1.0' or system='http://hl7.org.au/id/ahpra-registration-number').exists()"/>
+        <expression value="identifier.exists() implies identifier.where(system='http://ns.electronichealth.net.au/id/hi/hpii/1.0' or system='http://ns.electronichealth.net.au/id/medicare-prescriber-number' or system='http://ns.electronichealth.net.au/id/pcehr/caei/1.0' or system='http://hl7.org.au/id/ahpra-registration-number').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-practitioner"/>
       </constraint>
     </element>

--- a/input/resources/au-pd-practitioner.xml
+++ b/input/resources/au-pd-practitioner.xml
@@ -32,7 +32,7 @@
       <path value="Practitioner.identifier" />
       <slicing>
         <discriminator>
-          <type value="value" />
+          <type value="pattern" />
           <path value="type" />
         </discriminator>
         <rules value="open" />

--- a/input/resources/au-pd-practitioner.xml
+++ b/input/resources/au-pd-practitioner.xml
@@ -43,6 +43,10 @@
       <sliceName value="hpii" />
       <short value="HPI-I for Directory Entry Practitioner" />
       <definition value="National identifier for the individual provider" />
+      <type>
+        <code value="Identifier"/>
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/au-hpii" />
+      </type>
       <mustSupport value="true" />
     </element>
     <element id="Practitioner.active">

--- a/input/resources/au-pd-practitioner.xml
+++ b/input/resources/au-pd-practitioner.xml
@@ -37,6 +37,7 @@
         </discriminator>
         <rules value="open" />
       </slicing>
+      <mustSupport value="true" />
     </element>
     <element id="Practitioner.identifier:hpii">
       <path value="Practitioner.identifier" />

--- a/input/resources/au-pd-practitioner.xml
+++ b/input/resources/au-pd-practitioner.xml
@@ -37,6 +37,7 @@
         </discriminator>
         <rules value="open" />
       </slicing>
+      <min value="1"/>
       <mustSupport value="true" />
     </element>
     <element id="Practitioner.identifier:hpii">

--- a/input/resources/au-pd-practitionerrole.xml
+++ b/input/resources/au-pd-practitionerrole.xml
@@ -87,9 +87,9 @@
       </type>
       <mustSupport value="true" />
     </element>
-    <element id="PractitionerRole.identifier:vendorAssignedDirectoryIdentifier">
+    <element id="PractitionerRole.identifier:auvdi">
       <path value="PractitionerRole.identifier" />
-      <sliceName value="vendorAssignedDirectoryIdentifier" />
+      <sliceName value="auvdi" />
       <short value="Secure Messaging Vendor's Provider Identifier" />
       <definition value="Vendor allocated directory identifier this can be used for search for specific practitioner role directory entry and/or for routing of messages." />
       <type>

--- a/input/resources/au-pd-practitionerrole.xml
+++ b/input/resources/au-pd-practitionerrole.xml
@@ -22,7 +22,7 @@
         <key value="au-pd-pracrole-01"/>
         <severity value="error"/>
         <human value="At least one defined identifier, known to this AU PD Practitioner Role profile, must be present"/>
-        <expression value="identifier.where(type.coding.where(code='VDI' or code='EI') or system='http://ns.electronichealth.net.au/id/medicare-provider-number' or system='http://hl7.org.au/id/npio').exists()"/>
+        <expression value="identifier.exists() implies identifier.where(type.coding.where(code='VDI' or code='EI') or system='http://ns.electronichealth.net.au/id/medicare-provider-number' or system='http://hl7.org.au/id/npio').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-practitionerrole"/>
       </constraint>
     </element>

--- a/input/resources/au-pd-practitionerrole.xml
+++ b/input/resources/au-pd-practitionerrole.xml
@@ -98,45 +98,9 @@
       <definition value="Vendor allocated directory identifier this can be used for search for specific practitioner role directory entry and/or for routing of messages." />
       <type>
         <code value="Identifier" />
-        <profile value="http://hl7.org/fhir/StructureDefinition/Identifier" />
+        <profile value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-vdi" />
       </type>
       <mustSupport value="true" />
-    </element>
-    <element id="PractitionerRole.identifier:vendorAssignedDirectoryIdentifier.type">
-      <path value="PractitionerRole.identifier.type" />
-      <short value="Vendor assigned directory identifier type" />
-    </element>
-    <element id="PractitionerRole.identifier:vendorAssignedDirectoryIdentifier.type.coding">
-      <path value="PractitionerRole.identifier.type.coding" />
-      <short value="Vendor assigned directory identifier type code" />
-      <min value="1" />
-    </element>
-    <element id="PractitionerRole.identifier:vendorAssignedDirectoryIdentifier.type.coding.system">
-      <path value="PractitionerRole.identifier.type.coding.system" />
-      <short value="Vendor assigned directory identifier type coding system" />
-    </element>
-    <element id="PractitionerRole.identifier:vendorAssignedDirectoryIdentifier.type.coding.code">
-      <path value="PractitionerRole.identifier.type.coding.code" />
-      <fixedCode value="VDI" />
-    </element>
-    <element id="PractitionerRole.identifier:vendorAssignedDirectoryIdentifier.type.text">
-      <path value="PractitionerRole.identifier.type.text" />
-      <min value="1" />
-      <fixedString value="Secure Messaging Vendor Identifier Directory Entry" />
-    </element>
-    <element id="PractitionerRole.identifier:vendorAssignedDirectoryIdentifier.system">
-      <path value="PractitionerRole.identifier.system" />
-      <short value="Required vendor assigned identifier system URI" />
-    </element>
-    <element id="PractitionerRole.identifier:vendorAssignedDirectoryIdentifier.assigner">
-      <path value="PractitionerRole.identifier.assigner" />
-      <short value="Assigning vendor reference" />
-      <min value="1" />
-    </element>
-    <element id="PractitionerRole.identifier:vendorAssignedDirectoryIdentifier.assigner.display">
-      <path value="PractitionerRole.identifier.assigner.display" />
-      <short value="Assigning vendor name" />
-      <min value="1" />
     </element>
     <element id="PractitionerRole.active">
       <path value="PractitionerRole.active" />

--- a/input/resources/au-pd-practitionerrole.xml
+++ b/input/resources/au-pd-practitionerrole.xml
@@ -31,7 +31,7 @@
       <path value="PractitionerRole.identifier" />
       <slicing>
         <discriminator>
-          <type value="value" />
+          <type value="pattern" />
           <path value="type" />
         </discriminator>
         <rules value="open" />

--- a/input/resources/au-pd-practitionerrole.xml
+++ b/input/resources/au-pd-practitionerrole.xml
@@ -34,10 +34,6 @@
           <type value="pattern" />
           <path value="type" />
         </discriminator>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
         <rules value="open" />
       </slicing>
       <mustSupport value="true" />

--- a/input/resources/au-pd-practitionerrole.xml
+++ b/input/resources/au-pd-practitionerrole.xml
@@ -18,6 +18,13 @@
       </extension>
       <path value="PractitionerRole" />
       <definition value="Directory entry for a provider at a location for an organisation." />
+      <constraint>
+        <key value="au-pd-pracrole-01"/>
+        <severity value="error"/>
+        <human value="At least a known and defined identifier must be present"/>
+        <expression value="identifier.where(type.coding.where(code='VDI' or code='EI') or system='http://ns.electronichealth.net.au/id/medicare-provider-number' or system='http://hl7.org.au/id/npio').exists()"/>
+        <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-practitionerrole"/>
+      </constraint>
     </element>
     <element id="PractitionerRole.meta">
       <path value="PractitionerRole.meta" />

--- a/input/resources/au-pd-practitionerrole.xml
+++ b/input/resources/au-pd-practitionerrole.xml
@@ -31,7 +31,7 @@
       <path value="PractitionerRole.identifier" />
       <slicing>
         <discriminator>
-          <type value="pattern" />
+          <type value="value" />
           <path value="type" />
         </discriminator>
         <rules value="open" />

--- a/input/resources/au-pd-practitionerrole.xml
+++ b/input/resources/au-pd-practitionerrole.xml
@@ -21,7 +21,7 @@
       <constraint>
         <key value="au-pd-pracrole-01"/>
         <severity value="error"/>
-        <human value="At least a known and defined identifier must be present"/>
+        <human value="At least one defined identifier, known to this AU PD Practitioner Role profile, must be present"/>
         <expression value="identifier.where(type.coding.where(code='VDI' or code='EI') or system='http://ns.electronichealth.net.au/id/medicare-provider-number' or system='http://hl7.org.au/id/npio').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-practitionerrole"/>
       </constraint>

--- a/input/resources/au-pd-practitionerrole.xml
+++ b/input/resources/au-pd-practitionerrole.xml
@@ -36,6 +36,7 @@
         </discriminator>
         <rules value="open" />
       </slicing>
+      <min value="1"/>
       <mustSupport value="true" />
     </element>
     <element id="PractitionerRole.identifier.extension">

--- a/input/resources/au-pd-sm-endpoint.xml
+++ b/input/resources/au-pd-sm-endpoint.xml
@@ -16,6 +16,13 @@
       <path value="Endpoint" />
       <short value="Australian Secure Message Directory Endpoint Record" />
       <definition value="Endpoint defined for use in secure message addressing." />
+      <constraint>
+        <key value="au-pd-ep-01"/>
+        <severity value="error"/>
+        <human value="At least a known and defined identifier must be present"/>
+        <expression value="identifier.where(system='http://ns.electronichealth.net.au/smd/target').exists()"/>
+        <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-sm-endpoint"/>
+      </constraint>
     </element>
     <element id="Endpoint.meta">
       <path value="Endpoint.meta" />

--- a/input/resources/au-pd-sm-endpoint.xml
+++ b/input/resources/au-pd-sm-endpoint.xml
@@ -70,6 +70,7 @@
         </discriminator>
         <rules value="open" />
       </slicing>
+      <min value="1"/>
       <mustSupport value="true" />
     </element>
     <element id="Endpoint.identifier:smdtarget">

--- a/input/resources/au-pd-sm-endpoint.xml
+++ b/input/resources/au-pd-sm-endpoint.xml
@@ -65,7 +65,7 @@
       <path value="Endpoint.identifier" />
       <slicing>
         <discriminator>
-          <type value="pattern" />
+          <type value="value" />
           <path value="system" />
         </discriminator>
         <rules value="open" />

--- a/input/resources/au-pd-sm-endpoint.xml
+++ b/input/resources/au-pd-sm-endpoint.xml
@@ -70,6 +70,7 @@
         </discriminator>
         <rules value="open" />
       </slicing>
+      <mustSupport value="true" />
     </element>
     <element id="Endpoint.identifier:smdtarget">
       <path value="Endpoint.identifier" />

--- a/input/resources/au-pd-sm-endpoint.xml
+++ b/input/resources/au-pd-sm-endpoint.xml
@@ -77,19 +77,11 @@
       <sliceName value="smdtarget" />
       <short value="Secure Messaging Target Identifier" />
       <definition value="Secure messaging interface target identity included in addressing metadata.  This is the complete URL identifier that can be directly used in secure messaging.  This identifier should be matched when selecting the encrypting certificate data used for payload encryption also referenced from this endpoint." />
+      <type>
+        <code value="Identifier" />
+        <profile value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-smdtargetidentifier" />
+      </type>
       <mustSupport value="true" />
-    </element>
-    <element id="Endpoint.identifier:smdtarget.system">
-      <path value="Endpoint.identifier.system" />
-      <short value="Secure Messaging Delivery Target Identifier" />
-      <definition value="Target identifier suitable for Secure Message Delivery interface metadata content; also allows lookup for responses." />
-      <min value="1" />
-      <fixedUri value="http://ns.electronichealth.net.au/smd/target" />
-    </element>
-    <element id="Endpoint.identifier:smdtarget.value">
-      <path value="Endpoint.identifier.value" />
-      <short value="Secure messaging target identifier value" />
-      <min value="1" />
     </element>
     <element id="Endpoint.status">
       <path value="Endpoint.status" />

--- a/input/resources/au-pd-sm-endpoint.xml
+++ b/input/resources/au-pd-sm-endpoint.xml
@@ -20,7 +20,7 @@
         <key value="au-pd-ep-01"/>
         <severity value="error"/>
         <human value="At least one defined identifier, known to this AU PD Secure Messaging Endpoint profile, must be present"/>
-        <expression value="identifier.where(system='http://ns.electronichealth.net.au/smd/target').exists()"/>
+        <expression value="identifier.exists() implies identifier.where(system='http://ns.electronichealth.net.au/smd/target').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-sm-endpoint"/>
       </constraint>
     </element>

--- a/input/resources/au-pd-sm-endpoint.xml
+++ b/input/resources/au-pd-sm-endpoint.xml
@@ -65,8 +65,8 @@
       <path value="Endpoint.identifier" />
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="system" />
+          <type value="pattern" />
+          <path value="type" />
         </discriminator>
         <rules value="open" />
       </slicing>

--- a/input/resources/au-pd-sm-endpoint.xml
+++ b/input/resources/au-pd-sm-endpoint.xml
@@ -66,7 +66,7 @@
       <slicing>
         <discriminator>
           <type value="pattern" />
-          <path value="type" />
+          <path value="system" />
         </discriminator>
         <rules value="open" />
       </slicing>

--- a/input/resources/au-pd-sm-endpoint.xml
+++ b/input/resources/au-pd-sm-endpoint.xml
@@ -19,7 +19,7 @@
       <constraint>
         <key value="au-pd-ep-01"/>
         <severity value="error"/>
-        <human value="At least a known and defined identifier must be present"/>
+        <human value="At least one defined identifier, known to this AU PD Secure Messaging Endpoint profile, must be present"/>
         <expression value="identifier.where(system='http://ns.electronichealth.net.au/smd/target').exists()"/>
         <source value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-sm-endpoint"/>
       </constraint>

--- a/input/resources/au-pd-smdtargetidentifier.xml
+++ b/input/resources/au-pd-smdtargetidentifier.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="au-pd-smdtargetidentifier"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="0"/> 
+  </extension>
+  <url value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-smdtargetidentifier"/>
+  <name value="PDSMDTargetIdentifier"/>
+  <title value="PD Secure Messaging Delivery Target Identifier"/>
+  <status value="draft"/>
+  <description value="This identifier profile defines a Secure Messaging Delivery Target Identifier in an Australian provider directory context."/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <type value="Identifier"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Identifier">
+      <path value="Identifier"/>
+      <short value="Secure Messaging Delivery Target Identifier"/>
+      <definition value="Secure messaging interface target identity included in addressing metadata.  This is the complete URL identifier that can be directly used in secure messaging.  This identifier should be matched when selecting the encrypting certificate data used for payload encryption also referenced from this endpoint." />
+    </element>   
+    <element id="Identifier.system">
+      <path value="Identifier.system"/>
+      <short value="Vendor allocated URL" />
+      <definition value="System identifier namespace for the assigning vendor's identifier value."/>
+      <min value="1"/>
+      <fixedUri value="http://ns.electronichealth.net.au/smd/target" />
+    </element>
+    <element id="Identifier.value">
+      <path value="Identifier.value"/>
+      <short value="Vendor Identifier Value"/>
+      <definition value="Secure messaging target identifier value." />
+      <min value="1"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/input/resources/au-pd-vdi.xml
+++ b/input/resources/au-pd-vdi.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+    <id value="au-pd-vdi" />
+    <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+        <valueInteger value="2"/> 
+    </extension>
+    <url value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-vdi" />
+    <name value="AUVDIIdentifier" />
+    <title value="AU VDI Identifier" />
+    <status value="draft" />
+    <description value="This profile defines a ... TO COMPLETE ... in an Australian context." />
+    <kind value="complex-type" />
+    <abstract value="false" />
+    <type value="Identifier" />
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier" />
+    <derivation value="constraint" />
+    <differential>
+        <element id="Identifier">
+            <path value="Identifier" />
+            <short value="Vendor Directory Identifier" />
+            <definition value="A unique vendor identifier allocated to a provider directory entry." />
+        </element>
+        <element id="Identifier.type">
+            <path value="Identifier.type" />
+            <short value="Coded identifier type for VDI" />
+            <min value="1"/>
+            <patternCodeableConcept>
+                <coding>
+                    <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203" />
+                    <code value="VDI" />
+                </coding>
+            </patternCodeableConcept>
+        </element>
+        <element id="Identifier.system">
+            <path value="Identifier.system" />
+            <short value="Vendor allocated URL"/>
+            <definition value="Unique namespace for the assigning vendor's identifier value" />
+            <min value="1" />
+        </element>
+        <element id="Identifier.value">
+            <path value="Identifier.value" />
+            <short value="Vendor Identifier Value" />
+            <definition value="Assigning vendor's identifier value." />
+            <min value="1" />
+        </element>
+        <element id="Identifier.assigner">
+            <path value="Identifier.assigner" />
+            <short value="Secure messaging vendor organisation"/>
+            <min value="1"/>
+        </element>
+        <element id="Identifier.assigner.display">
+            <path value="Identifier.assigner.display" />
+            <short value="Secure messaging vendor organisation name"/>
+            <min value="1"/>
+        </element>
+    </differential>
+</StructureDefinition>

--- a/input/resources/au-pd-vdi.xml
+++ b/input/resources/au-pd-vdi.xml
@@ -2,13 +2,13 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
     <id value="au-pd-vdi" />
     <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-        <valueInteger value="2"/> 
+        <valueInteger value="0"/> 
     </extension>
     <url value="http://hl7.org.au/fhir/pd/StructureDefinition/au-pd-vdi" />
-    <name value="AUVDIIdentifier" />
-    <title value="AU VDI Identifier" />
+    <name value="AUVendorDirectoryIdentifier" />
+    <title value="AU Vendor Directory Identifier" />
     <status value="draft" />
-    <description value="This profile defines a ... TO COMPLETE ... in an Australian context." />
+    <description value="This identifier profile defines a vendor directory identifier allocated to a provider directory entry, in an Australian provider directory context." />
     <kind value="complex-type" />
     <abstract value="false" />
     <type value="Identifier" />
@@ -18,11 +18,11 @@
         <element id="Identifier">
             <path value="Identifier" />
             <short value="Vendor Directory Identifier" />
-            <definition value="A unique vendor identifier allocated to a provider directory entry." />
+            <definition value="Vendor Directory Identifiers typically assigned by a vendor that can be used to search for specific healthcare service directory entries and/or for routing of messages." />
         </element>
         <element id="Identifier.type">
             <path value="Identifier.type" />
-            <short value="Coded identifier type for VDI" />
+            <short value="Coded identifier type for vendor directory identifier" />
             <min value="1"/>
             <patternCodeableConcept>
                 <coding>


### PR DESCRIPTION
This PR firstly addresses the cleanup of a number of issues related to identifier definitions, as documented here: https://github.com/hl7au/au-fhir-pd/issues/45

And over and above those changes, the feature to mandate at least 1 known identifier was implemented; see feature request here: https://github.com/hl7au/au-fhir-pd/issues/36

The feature was implemented by: 

1. changing identifier cardinality on each profile to 1..* and
2. adding an invariant on each profile whereby at least one of the known identifiers (inherited from AU Base or introduced in this PD IG) must be present. 

To support this change, each profile has narrative describing this change in order to make it more prominent.

Note also that in a meeting with @brettesler-ext and @jakubsielewicz , on Wed 6 Dec 2023, it was decided that the PD Location profile identifier invariant should not be made mandatory but only as a warning. Therefore this invariant has constraint severity as 'warning' instead of 'error'.

To support these changes, some of which are breaking changes, the changelog has been comprehensively updated to describe changes related to identifiers and specifically call out what the breaking changes are.

Each of the profiles were tested across a wide sweep of possible scenario test cases, all of which result in the correct validation behaviour (passing and failing).